### PR TITLE
Change 'rehydrate' to 'reason-react' in bsconfig

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,7 +5,7 @@
 {
   "name" : "reductive",
   "reason" : { "react-jsx" : true},
-  "bs-dependencies": ["rehydrate", "reason-js"],
+  "bs-dependencies": ["reason-react", "reason-js"],
   "sources": [
     "src",
     {


### PR DESCRIPTION
From what I can tell `hydrate` was renamed to `reason-react`. This allows me to use the package straight from GitHub.