### PR TITLE
Point bucklescript dependency to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "rickyvetter",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "bs-platform": "https://github.com/bloomberg/bucklescript.git"
+    "bs-platform": "^1.6.0"
   },
   "devDependencies": {
     "immutable-re": "https://github.com/facebookincubator/immutable-re.git",


### PR DESCRIPTION
Right now when trying to add a new dependency to my project with Yarn, it will fail because of the postinstall step on `bs-platform`. Using the npm published version will alleviate that as it will have the OCaml source bundled with the npm package.

I do have a PR, https://github.com/bloomberg/bucklescript/pull/1480 that fixes the root problem.

Here is the error currently:

```
error /Users/nkist/Projects/reason-calculator/node_modules/reductive/node_modules/bs-platform: Command failed.
Exit code: 1
Command: sh
Arguments: -c node scripts/install.js
Directory: /Users/nkist/Projects/reason-calculator/node_modules/reductive/node_modules/bs-platform
Output:
Working dir /Users/nkist/Projects/reason-calculator/node_modules/reductive/node_modules/bs-platform
Prepare ninja binary
ninja binary is ready:  /Users/nkist/Projects/reason-calculator/node_modules/reductive/node_modules/bs-platform/bin/ninja.exe
Working dir /Users/nkist/Projects/reason-calculator/node_modules/reductive/node_modules/bs-platform/jscomp
/bin/sh: ocamlc.opt: command not found
configuration failure
fatal: destination path 'ocaml_src' already exists and is not an empty directory.
child_process.js:532
    throw err;
    ^

Error: Command failed: /Users/nkist/Projects/reason-calculator/node_modules/reductive/node_modules/bs-platform/scripts/buildocaml.sh
fatal: destination path 'ocaml_src' already exists and is not an empty directory.

    at checkExecSyncError (child_process.js:489:13)
    at Object.execSync (child_process.js:529:13)
    at non_windows_npm_release (/Users/nkist/Projects/reason-calculator/node_modules/reductive/node_modules/bs-platform/scripts/install.js:83:23)
    at Object.<anonymous> (/Users/nkist/Projects/reason-calculator/node_modules/reductive/node_modules/bs-platform/scripts/install.js:128:5)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
```