### PR TITLE
Fix Immutable-re dependency

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -2,7 +2,7 @@
   "name" : "reductive",
   "reason" : {"react-jsx" : true},
   "bs-dependencies": ["reason-react"],
-  "bs-dev-dependencies": ["reason-js", "Immutable.re"],
+  "bs-dev-dependencies": ["reason-js", "immutable-re"],
   "sources": [
     "src",
     {


### PR DESCRIPTION
This should properly import `Immutable-re` package. I'm not sure why this is tripping up my CI here: https://travis-ci.org/wyze/reason-calculator/jobs/219422895#L612 

I didn't think with the latest changes to `bs-platform` it shouldn't be included anyways. Also, if you clone this repo and run `npm start`, it will build now.